### PR TITLE
Minor run_tests bugfixes

### DIFF
--- a/pdn_project_allocation/run_tests.py
+++ b/pdn_project_allocation/run_tests.py
@@ -29,6 +29,7 @@ Run tests for pdn_project_allocation.
 
 import logging
 import os
+import sys
 import subprocess
 from typing import List
 
@@ -37,6 +38,7 @@ from cardinal_pythonlib.logs import main_only_quicksetup_rootlogger
 
 log = logging.getLogger(__name__)
 
+EXEC = sys.executable
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 PROG = os.path.join(THISDIR, "main.py")
 INPUTDIR = os.path.join(THISDIR, "testdata")
@@ -54,7 +56,7 @@ def process(
     infile: str, outfile: str, other_options: List[str] = None
 ) -> None:
     cmdargs = [
-        "python",
+        EXEC,
         PROG,
         os.path.join(INPUTDIR, infile),
         "--output",

--- a/pdn_project_allocation/run_tests.py
+++ b/pdn_project_allocation/run_tests.py
@@ -40,8 +40,10 @@ log = logging.getLogger(__name__)
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 PROG = os.path.join(THISDIR, "main.py")
 INPUTDIR = os.path.join(THISDIR, "testdata")
-OUTPUTDIR = os.path.join(THISDIR, os.pardir, "testoutput")
+OUTPUTDIR = os.path.join(os.getcwd(), "testoutput")
 
+if not os.path.exists(OUTPUTDIR):
+    os.makedirs(OUTPUTDIR)
 
 # =============================================================================
 # Tests


### PR DESCRIPTION
I was encountering some issues when executing the `pdn_project_allocation_run_tests` command:

1. A `FileNotFoundError` due to the `testoutput` directory not being present. 

2. When using a virtual environment - a `ModuleNotFoundError` as the global Python executable was being used.

The minor changes included in the PR helped to solve both issues, and I thought it may be worthwhile sharing.