### PR TITLE
Shortened heading text for unallocated projects with capacity to avoi…

### DIFF
--- a/pdn_project_allocation/constants.py
+++ b/pdn_project_allocation/constants.py
@@ -75,7 +75,7 @@ class SheetNames:
     SUPERVISOR_PREFERENCES = "Supervisor_preferences"  # input, output
     SUPERVISOR_PREFERENCES_INTERNAL = "Supervisor_preferences_internal"  # out
     SUPERVISORS = "Supervisors"  # input, output
-    UNALLOCATED_PROJECTS_WITH_CAPACITY = "Unallocated_projects_with_capacity"
+    UNALLOCATED_PROJECTS_WITH_CAPACITY = "Unalloc_projects_with_capacity"
 
 
 class SheetHeadings:


### PR DESCRIPTION
This is a proposed minor bug-fix arising from something I noticed when informally helping someone install/use this excellent software on Windows.

The execution log (Windows and Linux) reports the following warning (in both test and real scenarios):
`...openpyxl/workbook/child.py:99: UserWarning: Title is more than 31 characters. Some applications may not be able to read the file
warnings.warn("Title is more than 31 characters. Some applications may not be able to read the file")`

Whilst this doesn't cause LibreOffice Calc on Linux any problems (it just opens the result file as-created), when using Excel O365 on Windows and attempting to open the result file, an error dialog is shown:

_We found a problem with some content in _`<file>`_.  Do you want us to try to recover as much as we can?  If you trust the source of this workbook, click Yes._

If one clicks "Yes", another dialog appears:

_Repairs to_`<file>`_: Excel was able to open the file by repairing or removing unreadable content.  Repaired Records: Worksheet properties from /xl/workbool.xml part (Workbook)._

The resulting Excel sheet is then shown with the worksheet title _Unallocated_projects_with_capacity_ truncated to _Unallocated_projects_with_capac_.  

I have shortened the title in `constants.py` to less than 31 characters (_Unalloc_projects_with_capacity_).  This eliminates both the execution log warning and the Excel corruption/repair sequence (tested on the ten test scenarios in the package).

Using a lightly-adapted (to allow the differently named worksheets to be compared) version of [this](https://stackoverflow.com/a/77023765) xslx diff approach, I have checked that the remainder of the file contents from the revised version match those arising from the current master branch (aside from the run timestamp which differs as expected) in each of the ten test cases.